### PR TITLE
chore: normalize Slack CLI config

### DIFF
--- a/.slack/.gitignore
+++ b/.slack/.gitignore
@@ -1,3 +1,2 @@
 apps.dev.json
 cache/
-config.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 slack-bolt==1.29.0
 pytest==9.1.1
 ruff==0.15.20
-slack-cli-hooks<1
+slack-cli-hooks==0.3.0


### PR DESCRIPTION
Normalizes this sample's Slack CLI config to match the rest of the Bolt samples, part of a fleet-wide standardization pass:

- stop gitignoring `.slack/config.json` so the committed CLI project config is consistent (JS/TS + py-search)
- pin `slack-cli-hooks==0.3.0` for reproducible installs (Python only)

Opened as a **draft** for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)